### PR TITLE
Improve SkillTradeConnect landing page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,32 +1,41 @@
 "use client";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import styles from "../styles/HomePage.module.css";
 
 export default function HomePage() {
   const router = useRouter();
 
   return (
-    <main style={{
-      display: "flex", flexDirection: "column", alignItems: "center",
-      justifyContent: "center", minHeight: "100vh", background: "#f4f6f8"
-    }}>
-      <Image src="/tradesman.jpg" alt="Tradesmen working" width={180} height={180} style={{ borderRadius: 16, marginBottom: 24 }} />
-      <h1 style={{ color: "#0070f3", fontSize: "2.3rem", marginBottom: 8 }}>SkillTradeConnect</h1>
-      <h2 style={{ color: "#444", marginBottom: 16, fontWeight: 500 }}>The Social Network for Skilled Trades</h2>
-      <p style={{ maxWidth: 420, textAlign: "center", marginBottom: 28 }}>
-        Welcome to the only online home built just for tradespeople.  
-        Connect, share your craft, find jobs, and join a real community that values skilled hands.
+    <main className={styles.main}>
+      {/* Logo area */}
+      <div className={styles.logo}>
+        <Image
+          src="/tradesman.jpg"
+          alt="Tradesmen working"
+          width={60}
+          height={60}
+          style={{ borderRadius: "50%" }}
+        />
+        <h1 className={styles.title}>SkillTradeConnect</h1>
+      </div>
+      <h2 className={styles.tagline}>The Social Network for Skilled Trades</h2>
+      <p className={styles.description}>
+        Welcome to the only online home built just for tradespeople. Connect,
+        share your craft, find jobs, and join a real community that values
+        skilled hands.
       </p>
-      <button
-        onClick={() => router.push("/sign-in")}
-        style={{
-          background: "#0070f3", color: "white", padding: "14px 40px",
-          border: "none", borderRadius: 8, fontSize: "1.1rem", fontWeight: 600,
-          cursor: "pointer", boxShadow: "0 4px 16px rgba(0,0,0,0.08)"
-        }}
-      >
+      <div className={styles.icons}>🔧 ⚒️ 🧰</div>
+      <button className={styles.button} onClick={() => router.push("/sign-in")}> 
         Enter
       </button>
+      <footer className={styles.footer}>
+        Made for Tradesmen, by Tradesmen
+      </footer>
+      {/*
+        TODO: Add testimonials from real tradespeople to build trust.
+        TODO: Include quick links to training resources or local suppliers.
+      */}
     </main>
   );
 }

--- a/styles/HomePage.module.css
+++ b/styles/HomePage.module.css
@@ -1,0 +1,63 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  background-color: #f2f2f2;
+  padding: 1rem;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.title {
+  color: #355070;
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.tagline {
+  color: #22223b;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.description {
+  max-width: 420px;
+  margin-bottom: 1.5rem;
+  color: #22223b;
+}
+
+.icons {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.button {
+  background-color: #f76f00;
+  color: #22223b;
+  padding: 14px 40px;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.button:hover {
+  background-color: #ffe066;
+}
+
+.footer {
+  margin-top: 2rem;
+  color: #22223b;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- style landing page with trades-inspired palette
- refactor layout to be more inviting to tradespeople
- add CSS module for easier future updates

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842509942e88324a74d08eb404027da