### PR TITLE
Update docs for SkillTradeConnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,41 @@
-# TypeScript Next.js example
+# SkillTradeConnect
 
-This is a really simple project that shows the usage of Next.js with TypeScript.
+SkillTradeConnect is a simple Next.js and TypeScript application designed for tradespeople to share jobs and connect with each other. This project serves as the basis for a future social platform.
 
-## Deploy your own
+## Setup
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-typescript&project-name=with-typescript&repository-name=with-typescript)
+1. Install [Node.js](https://nodejs.org/) (version 18 or later).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The site will be available at `http://localhost:3000`.
 
-## How to use it?
+## Building and Running
 
-Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
+To create a production build, run:
 
 ```bash
-npx create-next-app --example with-typescript with-typescript-app
+npm run build
 ```
+
+Then start the compiled app with:
 
 ```bash
-yarn create next-app --example with-typescript with-typescript-app
+npm start
 ```
 
-```bash
-pnpm create next-app --example with-typescript with-typescript-app
-```
+Use `npm run type-check` if you want to run the TypeScript compiler in `noEmit` mode.
 
-Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
+## Project Structure
 
-## Notes
+- `pages/` – Next.js pages. Visit `/sign-in` and `/sign-up` to see the placeholder authentication screens.
+- `public/images/` – Static images used by the site. Add any new images here and reference them as `/images/<file>` in your components.
 
-This example shows how to integrate the TypeScript type system into Next.js. Since TypeScript is supported out of the box with Next.js, all we have to do is to install TypeScript.
+## Contributing
 
-```shell
-npm install --save-dev typescript
-```
-
-```shell
-yarn install --save-dev typescript
-```
-
-```shell
-pnpm install --save-dev typescript
-```
-
-To enable TypeScript's features, we install the type declarations for React and Node.
-
-```shell
-npm install --save-dev @types/react @types/react-dom @types/node
-```
-
-```shell
-yarn install --save-dev @types/react @types/react-dom @types/node
-```
-
-```shell
-pnpm install --save-dev @types/react @types/react-dom @types/node
-```
-
-When we run `next dev` the next time, Next.js will start looking for any `.ts` or `.tsx` files in our project and builds it. It even automatically creates a `tsconfig.json` file for our project with the recommended settings.
-
-Next.js has built-in TypeScript declarations, so we'll get autocompletion for Next.js' modules straight away.
-
-A `type-check` script is also added to `package.json`, which runs TypeScript's `tsc` CLI in `noEmit` mode to run type-checking separately. You can then include this, for example, in your `test` scripts.
-
-## Assets
-Place site images in `public/images`. Update `pages/index.tsx` to reference them as `/images/<file>`.
+Feel free to open issues or pull requests if you have suggestions or improvements for SkillTradeConnect.


### PR DESCRIPTION
## Summary
- overhaul README for SkillTradeConnect
- document the public images directory and sign-in/sign-up pages

## Testing
- no tests run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68428ceba0408324b0245684ad820162